### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/test/cli/gitBashTests.js
+++ b/test/cli/gitBashTests.js
@@ -27,7 +27,7 @@ if (process.platform !== 'win32') {
 function runInGitBash(commands, nvsHome) {
 	for (let i = commands.length - 1; i >= 0; i--) {
 		// Print each command before executing it.
-		commands.splice(i, 0, 'echo \\> ' + commands[i].replace('$', '\\$'));
+		commands.splice(i, 0, 'echo \\> ' + commands[i].replace(/\$/g, '\\$'));
 	}
 
 	// source rc file

--- a/test/cli/gitBashTests.js
+++ b/test/cli/gitBashTests.js
@@ -27,7 +27,7 @@ if (process.platform !== 'win32') {
 function runInGitBash(commands, nvsHome) {
 	for (let i = commands.length - 1; i >= 0; i--) {
 		// Print each command before executing it.
-		commands.splice(i, 0, 'echo \\> ' + commands[i].replace(/\$/g, '\\$'));
+		commands.splice(i, 0, 'echo \\> ' + commands[i].replace(/\\/g, '\\\\').replace(/\$/g, '\\$'));
 	}
 
 	// source rc file


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/nvs/security/code-scanning/3](https://github.com/thomas-iniguez-visioli/nvs/security/code-scanning/3)

To fix the issue, we need to ensure that all occurrences of the `$` character in `commands[i]` are escaped. This can be achieved by using a regular expression with the global (`g`) flag in the `replace` method. The updated code will replace every `$` in the string with `\$`.

The change will be made on line 30, where the `replace` method is currently used. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
